### PR TITLE
Add docker support for application and run tests agains integration tests db

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,7 +51,6 @@ The backend would still require to have extended coverage, including `Integratio
 - Adding Open API documentation
 - Migrating JDBC from repository to a ORM
 - Implement helper classes for the integration tests 
-- Create dedicated docker setup for Integration tests 
-- Dockerize application
 - Improve monitoring 
 - Add further validations
+- Add flyway for migrate database 

--- a/todo-backend/Dockerfile
+++ b/todo-backend/Dockerfile
@@ -1,0 +1,24 @@
+FROM openjdk:21-jdk-slim
+
+WORKDIR /app
+
+COPY gradlew /app/
+COPY gradlew.bat /app/
+COPY gradle /app/gradle
+
+COPY build.gradle.kts /app/
+COPY settings.gradle.kts /app/
+
+COPY src /app/src
+
+RUN chmod +x gradlew
+
+RUN ./gradlew build -x test --no-daemon
+
+RUN ./gradlew shadowJar --no-daemon
+
+COPY build/libs/*-all.jar app.jar
+
+EXPOSE 8080
+
+ENTRYPOINT ["java", "-jar", "app.jar"]

--- a/todo-backend/build.gradle.kts
+++ b/todo-backend/build.gradle.kts
@@ -51,6 +51,7 @@ java {
 graalvmNative.toolchainDetection = false
 micronaut {
     runtime("netty")
+    version("4.5.0")
     testRuntime("junit5")
     processing {
         incremental(true)
@@ -70,6 +71,17 @@ micronaut {
     }
 }
 
+tasks.withType<Jar> {
+    manifest {
+        attributes["Main-Class"] = "com.brognilucas.ApplicationKt"
+    }
+}
+tasks.named<com.github.jengelman.gradle.plugins.shadow.tasks.ShadowJar>("shadowJar") {
+    mergeServiceFiles()
+    manifest {
+        attributes["Main-Class"] = "com.brognilucas.ApplicationKt"
+    }
+}
 
 tasks.named<io.micronaut.gradle.docker.NativeImageDockerfile>("dockerfileNative") {
     jdkVersion = "21"

--- a/todo-backend/docker-compose.yml
+++ b/todo-backend/docker-compose.yml
@@ -12,4 +12,29 @@ services:
     ports:
       - "3306:3306"
     volumes:
-      - ./init.sql:/docker-entrypoint-initdb.d/init.sql  # Mount init.sql into MySQL container
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  db-integration-tests:
+    image: mysql:8.0
+    container_name: mysql-integration-tests
+    environment:
+      MYSQL_ROOT_PASSWORD: root_password
+      MYSQL_DATABASE: todo_db_integration
+      MYSQL_USER: user
+      MYSQL_PASSWORD: password
+    ports:
+      - "3307:3306"
+    volumes:
+      - ./init.sql:/docker-entrypoint-initdb.d/init.sql
+
+  backend:
+    build: .
+    ports:
+      - "8081:8080"
+    depends_on:
+      - db
+    environment:
+      DATASOURCES_DEFAULT_URL: jdbc:mysql://db:3306/todo_db
+      DATASOURCES_DEFAULT_DRIVER_CLASS_NAME: com.mysql.cj.jdbc.Driver
+      DATASOURCES_DEFAULT_USERNAME: user
+      DATASOURCES_DEFAULT_PASSWORD: password

--- a/todo-backend/src/main/resources/application.properties
+++ b/todo-backend/src/main/resources/application.properties
@@ -2,9 +2,9 @@ datasources.default.db-type=mysql
 datasources.default.dialect=MYSQL
 datasources.default.schema-generate=CREATE_DROP
 datasources.default.driver-class-name=com.mysql.cj.jdbc.Driver
-datasources.default.url=jdbc:mysql://localhost:3306/todo_db
-datasources.default.username=user
-datasources.default.password=password
+datasources.default.url=${DB_URL:jdbc:mysql://localhost:3306/todo_db}
+datasources.default.username=${DB_USER:default_user}
+datasources.default.password=${DB_PASSWORD:default_password}
 
 micronaut.application.name=todo-backend
 micronaut.server.cors.enabled=true

--- a/todo-backend/src/main/resources/db/migrations/V1__create_todo_table.sql
+++ b/todo-backend/src/main/resources/db/migrations/V1__create_todo_table.sql
@@ -1,5 +1,0 @@
-CREATE TABLE todo (
-    id BIGINT AUTO_INCREMENT PRIMARY KEY,
-    title VARCHAR(255) NOT NULL,
-    completed BOOLEAN NOT NULL DEFAULT false
-);

--- a/todo-backend/src/test/kotlin/com/brognilucas/TodoControllerTest.kt
+++ b/todo-backend/src/test/kotlin/com/brognilucas/TodoControllerTest.kt
@@ -10,13 +10,15 @@ import io.micronaut.http.client.annotation.Client
 import io.micronaut.runtime.server.EmbeddedServer
 import io.micronaut.test.extensions.junit5.annotation.MicronautTest
 import jakarta.inject.Inject
+import org.junit.jupiter.api.AfterEach
 import org.junit.jupiter.api.Assertions.assertEquals
-import org.junit.jupiter.api.BeforeEach
 import org.junit.jupiter.api.Test
 import java.sql.Connection
 import java.sql.DriverManager
 
-@MicronautTest
+@MicronautTest(
+    environments = ["test"],
+)
 class TodoControllerTest(private val embeddedServer: EmbeddedServer) {
 
     @Inject
@@ -43,7 +45,7 @@ class TodoControllerTest(private val embeddedServer: EmbeddedServer) {
         return response;
     }
 
-    @BeforeEach
+    @AfterEach
     fun setup() {
         getConnection().use { conn ->
             val stmt = conn.createStatement()

--- a/todo-backend/src/test/resources/application-test.properties
+++ b/todo-backend/src/test/resources/application-test.properties
@@ -1,0 +1,10 @@
+micronaut.application.name=todo-backend-test
+
+# Datasource Configuration for integration tests
+datasources.default.db-type=mysql
+datasources.default.dialect=MYSQL
+datasources.default.schema-generate=CREATE_DROP
+datasources.default.driver-class-name=com.mysql.cj.jdbc.Driver
+datasources.default.url=jdbc:mysql://localhost:3307/todo_db_integration
+datasources.default.username=user
+datasources.default.password=password


### PR DESCRIPTION
- This MR adds docker for the application 
- Extends the docker-compose file by adding and allowing the application to be run with the db 
- Extends the docker-compose file by creating a database for tests 
- Creates a config file for the tests 
- Changes clean of db to happen @AfterEach test so db get's clean on finish